### PR TITLE
Fix priority enumeration values

### DIFF
--- a/Firebase-Cloud-Messaging-Net/Requests/Enumerations.cs
+++ b/Firebase-Cloud-Messaging-Net/Requests/Enumerations.cs
@@ -8,10 +8,10 @@ namespace net.tipstrade.FCMNet.Requests {
   [JsonConverter(typeof(StringEnumConverter))]
   public enum Priority {
     /// <summary></summary>
-    [EnumMember(Value = " normal")]
+    [EnumMember(Value = "normal")]
     Normal,
     /// <summary></summary>
-    [EnumMember(Value = " high")]
+    [EnumMember(Value = "high")]
     High
   }
 }


### PR DESCRIPTION
I removed space from enums values that causes an HTTP 400 error response from FCM.